### PR TITLE
Fixes the issue #5

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -931,11 +931,9 @@ impl<'a, T: PipeIo> ReadHandle<'a, T> {
             if let Some(buf) = buffer {
                 if let Some(io) = io {
                     Ok((bytes_read as usize, Some((io, buf))))
-                } else if let Some(io_ref) = io_ref {
-                    if let Some(original_buffer) = original_buffer {
-                        for i in 0..buf.len() {
-                            original_buffer[i] = buf[i];
-                        }
+                } else if let (Some(io_ref), Some(mut original_buffer)) = (io_ref, original_buffer) {
+                    for i in 0..buf.len() {
+                        original_buffer[i] = buf[i];
                     }
                     Ok((bytes_read as usize, None))
                 } else {


### PR DESCRIPTION
The problem in #5 is, that the assignment of the fixed-size static-initialized array re-uses the same physical memory address every time the function gets called. This is possible because the buffer goes out of scope after the function returns and the compiler assumes that there is no other reference to this memory.

But the writing to the buffer happens outside of rust (through the winapi, in an unsafe block), therefor it doesn't know that the buffer was dropped in the meantime. Kind of like a dangling pointer.

The best solution is to copy the array into a vec and use the copy for the read operation. If the read is successful, write the read values back in the originial buffer.

Alternatively you could create a zeroed vector of the same length. This would guarantee, that only the data which was read from the pipe gets copied into the buffer, but would also be a different behaviour than right now. Therfor I decided to not do that right now, in order to not break any existing code.

I also did the same for the write operation, because this would suffer from a similar problem.